### PR TITLE
fix: restore hidden friends list

### DIFF
--- a/components/FriendsHiddenLinks.vue
+++ b/components/FriendsHiddenLinks.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import type { FriendLink } from '../utils/friends'
+
+defineProps<{
+  checkedAt: string
+  links: FriendLink[]
+  revision: number
+}>()
+</script>
+
+<template>
+  <section v-if="links.length" class="hidden-friends" aria-labelledby="hidden-friends-title">
+    <details class="hidden-friends-details">
+      <summary class="hidden-friends-summary">
+        <span class="hidden-friends-icon i-ri-ghost-line" aria-hidden="true" />
+        <span class="hidden-friends-copy">
+          <strong id="hidden-friends-title">神隐友链</strong>
+          <span>有些朋友只是暂时离线，保留在这里等待重逢。</span>
+        </span>
+        <span class="hidden-friends-count" :aria-label="`${links.length} 个站点`">
+          {{ links.length }}
+        </span>
+        <span class="hidden-friends-chevron i-ri-arrow-down-s-line" aria-hidden="true" />
+      </summary>
+
+      <div class="hidden-friends-body">
+        <p>
+          以下站点在 {{ checkedAt }} 的多次检查中均无法访问，之后会定期复查。
+        </p>
+        <YunLinks :key="revision" :links="links" :random="false" />
+      </div>
+    </details>
+  </section>
+</template>
+
+<style scoped>
+.hidden-friends {
+  margin: 2rem 0 1rem;
+}
+
+.hidden-friends-details {
+  overflow: hidden;
+  background: color-mix(in srgb, var(--va-c-bg-soft) 72%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--va-c-border) 82%, transparent);
+  border-radius: 0.875rem;
+  transition: border-color var(--va-transition-duration-fast) ease;
+}
+
+.hidden-friends-details[open] {
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--va-c-primary) 32%, var(--va-c-border));
+}
+
+.hidden-friends-summary {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 1rem 1.125rem;
+  color: var(--va-c-text);
+  cursor: pointer;
+  list-style: none;
+  transition: background-color var(--va-transition-duration-fast) ease;
+}
+
+.hidden-friends-summary::-webkit-details-marker {
+  display: none;
+}
+
+.hidden-friends-summary:hover {
+  background: color-mix(in srgb, var(--va-c-primary) 6%, transparent);
+}
+
+.hidden-friends-summary:focus-visible {
+  outline: 2px solid var(--va-c-primary);
+  outline-offset: -2px;
+}
+
+.hidden-friends-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--va-c-text-light);
+}
+
+.hidden-friends-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.hidden-friends-copy strong {
+  font-family: var(--va-font-serif);
+  font-size: 1rem;
+}
+
+.hidden-friends-copy span {
+  color: var(--va-c-text-light);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.hidden-friends-count {
+  min-width: 1.75rem;
+  padding: 0.15rem 0.5rem;
+  color: var(--va-c-text-light);
+  text-align: center;
+  font-size: 0.75rem;
+  background: var(--va-c-bg);
+  border: 1px solid var(--va-c-border);
+  border-radius: 999px;
+}
+
+.hidden-friends-chevron {
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--va-c-text-light);
+  transition: transform var(--va-transition-duration-fast) ease;
+}
+
+.hidden-friends-details[open] .hidden-friends-chevron {
+  transform: rotate(180deg);
+}
+
+.hidden-friends-body {
+  padding: 0 1.125rem 1.125rem;
+  border-top: 1px solid color-mix(in srgb, var(--va-c-border) 60%, transparent);
+}
+
+.hidden-friends-body > p {
+  margin: 1rem 0 0;
+  color: var(--va-c-text-light);
+  font-size: 0.85rem;
+}
+
+.hidden-friends-body :deep(.yun-link-items) {
+  margin-bottom: 0;
+}
+
+.hidden-friends-body :deep(.yun-link-url) {
+  border-style: dashed;
+  box-shadow: none;
+  filter: saturate(0.55);
+  opacity: 0.8;
+}
+
+@media (max-width: 640px) {
+  .hidden-friends-summary {
+    gap: 0.625rem;
+    padding: 0.875rem;
+  }
+
+  .hidden-friends-copy span {
+    font-size: 0.76rem;
+  }
+
+  .hidden-friends-body {
+    padding: 0 0.875rem 0.875rem;
+  }
+}
+</style>

--- a/components/FriendsLinks.vue
+++ b/components/FriendsLinks.vue
@@ -1,16 +1,29 @@
 <script setup lang="ts">
 import type { FriendsStorage } from '../utils/friends'
 import { onMounted, ref } from 'vue'
+import hiddenFriends, {
+  friendOverrides,
+  HIDDEN_FRIENDS_CHECKED_AT,
+} from '../config/friends'
 import {
+  applyFriendOverrides,
   chooseInitialFriends,
   FRIENDS_SOURCE_URL,
   readFriendsCache,
   refreshFriends,
   shuffleFriends,
+  splitFriendsByHiddenLinks,
 } from '../utils/friends'
 import generatedFriends from '../utils/generated-friends'
 
-const links = ref(generatedFriends)
+const initialGroups = splitFriendsByHiddenLinks(
+  applyFriendOverrides(generatedFriends, friendOverrides),
+  hiddenFriends,
+)
+const links = ref(initialGroups.active)
+const hiddenLinks = ref(initialGroups.hidden)
+// YunLinks snapshots its initial links prop, so replacements must remount it.
+const linksRevision = ref(0)
 
 const unavailableStorage: FriendsStorage = {
   getItem: () => null,
@@ -27,17 +40,27 @@ function getStorage() {
   }
 }
 
+function replaceLinks(nextLinks: typeof generatedFriends) {
+  const groups = splitFriendsByHiddenLinks(
+    applyFriendOverrides(nextLinks, friendOverrides),
+    hiddenFriends,
+  )
+  links.value = shuffleFriends(groups.active)
+  hiddenLinks.value = groups.hidden
+  linksRevision.value += 1
+}
+
 onMounted(() => {
   const storage = getStorage()
   const cachedLinks = readFriendsCache(storage)
-  links.value = shuffleFriends(chooseInitialFriends(generatedFriends, cachedLinks))
+  replaceLinks(chooseInitialFriends(generatedFriends, cachedLinks))
 
   void refreshFriends(links.value, {
     storage,
     url: FRIENDS_SOURCE_URL,
   }).then((result) => {
     if (result.changed)
-      links.value = shuffleFriends(result.links)
+      replaceLinks(result.links)
   }).catch(() => {
     // Keep the SSG or cached links when the runtime request is unavailable.
   })
@@ -45,10 +68,15 @@ onMounted(() => {
 </script>
 
 <template>
-  <YunLinks v-if="links.length" :links="links" :random="false" />
+  <YunLinks v-if="links.length" :key="linksRevision" :links="links" :random="false" />
   <div v-else class="friends-loading" aria-live="polite">
     友链加载中…
   </div>
+  <FriendsHiddenLinks
+    :links="hiddenLinks"
+    :revision="linksRevision"
+    :checked-at="HIDDEN_FRIENDS_CHECKED_AT"
+  />
 </template>
 
 <style scoped>

--- a/config/friends.ts
+++ b/config/friends.ts
@@ -1,0 +1,100 @@
+import type { FriendLink } from '../utils/friends'
+
+export interface HiddenFriend extends FriendLink {
+  hiddenAt: string
+  reason: string
+}
+
+export const HIDDEN_FRIENDS_CHECKED_AT = '2026-07-19'
+
+export const friendOverrides: Record<string, Partial<FriendLink>> = {
+  'https://blog.besscroft.com/': {
+    avatar: 'https://github.com/besscroft.png?size=512',
+    url: 'https://besscroft.com/',
+  },
+}
+
+const hiddenFriends = [
+  {
+    avatar: 'https://upyun.yunyoujun.cn/images/angelic47-avatar.jpg',
+    name: 'Angelic47',
+    url: 'https://www.angelic47.com/',
+    color: '#4fbff9',
+    blog: 'Angelic47\'s Home',
+    desc: '弱小，无助，又可怜！～',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+  {
+    avatar: 'https://fastly.jsdelivr.net/gh/BigCoke233/image-hosting/avatars/avatar.jpg',
+    name: 'Eltrac',
+    url: 'https://guhub.cn',
+    color: '#6688DD',
+    blog: 'Eltrac\'s Track',
+    desc: '暗夜行路，终遇奇迹。',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+  {
+    avatar: 'https://upyun.yunyoujun.cn/images/hydropower-avatar.jpg',
+    name: 'Andy Chen',
+    url: 'https://hydropwr.ca/',
+    color: '#00A9EF',
+    blog: 'Hydropower Hub',
+    desc: 'また，一緒に輝きたい．',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+  {
+    avatar: 'https://haozi.moe/css/images/logo.png',
+    name: '月月月子喵',
+    url: 'https://haozi.moe/',
+    color: '#42b983',
+    blog: '月月月子喵~',
+    desc: '可爱的月子酱',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: 'HTTPS 连接失败，HTTP 返回 404 页面',
+  },
+  {
+    avatar: 'https://github.com/cbhua/cbhua.github.io/raw/master/images/icon.png',
+    name: 'Kurakun',
+    url: 'https://timegg.top',
+    color: '#1C5A97',
+    blog: 'Timegg',
+    desc: '把手上的东西放进时光蛋。',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+  {
+    avatar: 'https://fastly.jsdelivr.net/gh/sanshiliuxiao/blog-static/avatar.jpg',
+    name: '椎咲良田',
+    url: 'https://sanshiliuxiao.top/',
+    color: '#4f5b97',
+    blog: '椎咲良田',
+    desc: '快走吧，趁风停止之前',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+  {
+    avatar: 'https://fastly.jsdelivr.net/gh/DavinciEvans/Imgs-bed@master/gallery/avatar.jpg',
+    name: 'Davinci',
+    url: 'https://davincievans.top/',
+    color: '#42b8dd',
+    blog: 'Davinci の 红茶馆',
+    desc: 'You are all stardust.',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+  {
+    avatar: 'https://img.cdn.gaein.cn/website_used/avatars/avatar-128x.webp',
+    name: 'Gaein nidb',
+    url: 'https://gaein.cn/',
+    color: '#519BFF',
+    blog: 'Gaein nidb 的小站',
+    desc: '记录生活',
+    hiddenAt: HIDDEN_FRIENDS_CHECKED_AT,
+    reason: '域名已无法解析',
+  },
+] satisfies HiddenFriend[]
+
+export default hiddenFriends

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "npm run sync:friends && npm run fuse && npm run build:ssg",
     "build:spa": "valaxy build",
     "build:ssg": "valaxy build --ssg --log=info",
+    "check:friends": "tsx scripts/check-friends.ts",
     "clean": "rm -rf dist",
     "dev": "valaxy",
     "fuse": "valaxy fuse",

--- a/pages/links/index.md
+++ b/pages/links/index.md
@@ -8,11 +8,6 @@ comments: true
 
 <FriendsLinks />
 
-<details>
-<summary>神隐</summary>
-
-</details>
-
 ## 友链说明
 
 每次刷新为随机顺序展示～

--- a/scripts/check-friends.ts
+++ b/scripts/check-friends.ts
@@ -1,0 +1,255 @@
+import type { FriendLink } from '../utils/friends.ts'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+import hiddenFriends, { friendOverrides } from '../config/friends.ts'
+import {
+  applyFriendOverrides,
+  fetchFriends,
+  FRIENDS_SOURCE_URL,
+  friendUrlKey,
+} from '../utils/friends.ts'
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+export type FriendHealthStatus = 'reachable' | 'restricted' | 'unreachable'
+
+export interface FriendHealthResult {
+  durationMs: number
+  finalUrl?: string
+  httpStatus?: number
+  knownHidden: boolean
+  name: string
+  reason?: string
+  status: FriendHealthStatus
+  url: string
+}
+
+export interface FriendHealthReport {
+  checkedAt: string
+  results: FriendHealthResult[]
+  source: string
+  summary: {
+    knownHidden: number
+    newUnreachable: number
+    reachable: number
+    recovered: number
+    restricted: number
+    unreachable: number
+  }
+}
+
+interface CheckFriendOptions {
+  attempts?: number
+  fetchImpl?: FetchLike
+  timeoutMs?: number
+}
+
+interface CheckFriendsOptions extends CheckFriendOptions {
+  concurrency?: number
+}
+
+interface RunHealthCheckOptions extends CheckFriendsOptions {
+  friends?: FriendLink[]
+  outputFile?: string
+  sourceUrl?: string
+}
+
+const DEFAULT_ATTEMPTS = 2
+const DEFAULT_CONCURRENCY = 8
+const DEFAULT_OUTPUT_FILE = resolve('.valaxy/friends-health.json')
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export function classifyHttpStatus(status: number): FriendHealthStatus {
+  if (status >= 200 && status < 400)
+    return 'reachable'
+
+  if ([401, 403, 407, 429].includes(status))
+    return 'restricted'
+
+  return 'unreachable'
+}
+
+function describeError(error: unknown) {
+  if (!(error instanceof Error))
+    return String(error)
+
+  const cause = (error as Error & {
+    cause?: { code?: string, message?: string }
+  }).cause
+  const detail = [cause?.code, cause?.message].filter(Boolean).join(': ')
+
+  return detail || error.message
+}
+
+export async function checkFriendSite(
+  friend: FriendLink,
+  options: CheckFriendOptions = {},
+): Promise<FriendHealthResult> {
+  const {
+    attempts = DEFAULT_ATTEMPTS,
+    fetchImpl = fetch,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = options
+  const startedAt = Date.now()
+  let lastReason = 'Unknown error'
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const response = await fetchImpl(friend.url, {
+        headers: {
+          'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'user-agent': 'Mozilla/5.0 (compatible; YunYouJunFriendsHealth/1.0; +https://www.yunyoujun.cn/links/)',
+        },
+        redirect: 'follow',
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+      const status = classifyHttpStatus(response.status)
+      await response.body?.cancel().catch(() => {})
+
+      if (status === 'unreachable' && response.status >= 500 && attempt + 1 < attempts) {
+        lastReason = `HTTP ${response.status}`
+        continue
+      }
+
+      return {
+        durationMs: Date.now() - startedAt,
+        finalUrl: response.url || friend.url,
+        httpStatus: response.status,
+        knownHidden: false,
+        name: friend.name,
+        reason: status === 'reachable' ? undefined : `HTTP ${response.status}`,
+        status,
+        url: friend.url,
+      }
+    }
+    catch (error) {
+      lastReason = describeError(error)
+      if (attempt + 1 < attempts)
+        continue
+    }
+  }
+
+  return {
+    durationMs: Date.now() - startedAt,
+    knownHidden: false,
+    name: friend.name,
+    reason: lastReason,
+    status: 'unreachable',
+    url: friend.url,
+  }
+}
+
+export async function checkFriends(
+  friends: FriendLink[],
+  options: CheckFriendsOptions = {},
+) {
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_CONCURRENCY)
+  const results: FriendHealthResult[] = []
+  let nextIndex = 0
+
+  async function worker() {
+    while (nextIndex < friends.length) {
+      const index = nextIndex++
+      results[index] = await checkFriendSite(friends[index], options)
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, friends.length) }, () => worker()),
+  )
+
+  return results
+}
+
+export async function runHealthCheck(options: RunHealthCheckOptions = {}) {
+  const sourceUrl = options.sourceUrl ?? FRIENDS_SOURCE_URL
+  const sourceFriends = options.friends ?? await fetchFriends(sourceUrl)
+  const friends = applyFriendOverrides(sourceFriends, friendOverrides)
+  const knownUrls = new Set(friends.map(friend => friend.url))
+  for (const friend of hiddenFriends) {
+    if (!knownUrls.has(friend.url))
+      friends.push(friend)
+  }
+  const hiddenUrls = new Set(hiddenFriends.map(friend => friendUrlKey(friend.url)))
+  const results = (await checkFriends(friends, options)).map(result => ({
+    ...result,
+    knownHidden: hiddenUrls.has(friendUrlKey(result.url)),
+  }))
+  const knownHidden = results.filter(result => result.knownHidden).length
+  const newUnreachable = results.filter(
+    result => result.status === 'unreachable' && !result.knownHidden,
+  ).length
+  const recovered = results.filter(
+    result => result.status === 'reachable' && result.knownHidden,
+  ).length
+  const report: FriendHealthReport = {
+    checkedAt: new Date().toISOString(),
+    results,
+    source: sourceUrl,
+    summary: {
+      knownHidden,
+      newUnreachable,
+      reachable: results.filter(result => result.status === 'reachable').length,
+      recovered,
+      restricted: results.filter(result => result.status === 'restricted').length,
+      unreachable: results.filter(result => result.status === 'unreachable').length,
+    },
+  }
+  const outputFile = options.outputFile ?? DEFAULT_OUTPUT_FILE
+
+  await mkdir(dirname(outputFile), { recursive: true })
+  await writeFile(outputFile, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+
+  return { outputFile, report }
+}
+
+function numberArgument(name: string, fallback: number) {
+  const prefix = `--${name}=`
+  const argument = process.argv.find(value => value.startsWith(prefix))
+  const value = Number(argument?.slice(prefix.length))
+  return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function stringArgument(name: string, fallback: string) {
+  const prefix = `--${name}=`
+  return process.argv.find(value => value.startsWith(prefix))?.slice(prefix.length) || fallback
+}
+
+async function main() {
+  const { outputFile, report } = await runHealthCheck({
+    attempts: numberArgument('attempts', DEFAULT_ATTEMPTS),
+    concurrency: numberArgument('concurrency', DEFAULT_CONCURRENCY),
+    outputFile: resolve(stringArgument('output', DEFAULT_OUTPUT_FILE)),
+    timeoutMs: numberArgument('timeout', DEFAULT_TIMEOUT_MS),
+  })
+
+  for (const result of report.results) {
+    if (result.status === 'reachable' && result.knownHidden) {
+      console.info(`[friends] recovered: ${result.name} <${result.url}>`)
+      continue
+    }
+
+    if (result.status === 'reachable')
+      continue
+
+    const detail = result.httpStatus ? `HTTP ${result.httpStatus}` : result.reason
+    const status = result.knownHidden ? 'known-hidden' : result.status
+    console.warn(`[friends] ${status}: ${result.name} <${result.url}> (${detail})`)
+  }
+
+  console.info(
+    `[friends] Checked ${report.results.length}: ${report.summary.reachable} reachable, ${report.summary.restricted} restricted, ${report.summary.unreachable} unreachable; ${report.summary.knownHidden} known hidden, ${report.summary.newUnreachable} new candidates, ${report.summary.recovered} recovered`,
+  )
+  console.info(`[friends] Report: ${outputFile}`)
+
+  if (process.argv.includes('--strict') && report.summary.newUnreachable > 0)
+    process.exitCode = 1
+}
+
+const isExecutedDirectly = process.argv[1]
+  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+
+if (isExecutedDirectly)
+  await main()

--- a/tests/check-friends.test.ts
+++ b/tests/check-friends.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+// eslint-disable-next-line test/no-import-node-test
+import test from 'node:test'
+import {
+  checkFriends,
+  checkFriendSite,
+  classifyHttpStatus,
+} from '../scripts/check-friends.ts'
+
+const friend = {
+  avatar: 'https://example.com/avatar.png',
+  name: 'Friend',
+  url: 'https://example.com',
+  color: '#fff',
+  blog: 'Blog',
+  desc: 'Description',
+}
+
+test('classifies successful, restricted, and broken HTTP responses', () => {
+  assert.equal(classifyHttpStatus(204), 'reachable')
+  assert.equal(classifyHttpStatus(302), 'reachable')
+  assert.equal(classifyHttpStatus(403), 'restricted')
+  assert.equal(classifyHttpStatus(429), 'restricted')
+  assert.equal(classifyHttpStatus(404), 'unreachable')
+  assert.equal(classifyHttpStatus(503), 'unreachable')
+})
+
+test('retries server and network failures', async () => {
+  let serverAttempts = 0
+  const serverResult = await checkFriendSite(friend, {
+    attempts: 2,
+    fetchImpl: async () => {
+      serverAttempts++
+      return new Response('', { status: serverAttempts === 1 ? 503 : 200 })
+    },
+  })
+
+  assert.equal(serverAttempts, 2)
+  assert.equal(serverResult.status, 'reachable')
+  assert.equal(serverResult.knownHidden, false)
+
+  let networkAttempts = 0
+  const networkResult = await checkFriendSite(friend, {
+    attempts: 2,
+    fetchImpl: async () => {
+      networkAttempts++
+      throw new Error('connection refused')
+    },
+  })
+
+  assert.equal(networkAttempts, 2)
+  assert.equal(networkResult.status, 'unreachable')
+  assert.equal(networkResult.reason, 'connection refused')
+})
+
+test('checks friends concurrently while preserving source order', async () => {
+  const another = { ...friend, name: 'Another', url: 'https://another.example' }
+  const results = await checkFriends([friend, another], {
+    concurrency: 2,
+    fetchImpl: async input => new Response('', {
+      status: String(input).includes('another') ? 403 : 200,
+    }),
+  })
+
+  assert.deepEqual(results.map(result => result.name), ['Friend', 'Another'])
+  assert.deepEqual(results.map(result => result.status), ['reachable', 'restricted'])
+})

--- a/tests/friends.test.ts
+++ b/tests/friends.test.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict'
 // eslint-disable-next-line test/no-import-node-test
 import test from 'node:test'
+import hiddenFriends from '../config/friends.ts'
 import {
+  applyFriendOverrides,
   chooseInitialFriends,
   fetchFriends,
   FRIENDS_CACHE_KEY,
@@ -12,6 +14,7 @@ import {
   refreshFriends,
   sameFriends,
   shuffleFriends,
+  splitFriendsByHiddenLinks,
   writeFriendsCache,
 } from '../utils/friends.ts'
 
@@ -145,4 +148,28 @@ test('build data wins and cache is only the empty-build fallback', () => {
   assert.deepEqual(chooseInitialFriends([friend], cached), [friend])
   assert.deepEqual(chooseInitialFriends([], cached), cached)
   assert.deepEqual(chooseInitialFriends([], null), [])
+})
+
+test('applies local overrides and separates hidden friends', () => {
+  const hidden = { ...friend, url: 'https://hidden.example/' }
+  const overridden = applyFriendOverrides([friend, hidden], {
+    'https://example.com': { url: 'https://new.example', desc: 'Updated' },
+  })
+  const groups = splitFriendsByHiddenLinks(overridden, [{ ...hidden, desc: 'Archived' }])
+
+  assert.deepEqual(groups.active, [{ ...friend, url: 'https://new.example', desc: 'Updated' }])
+  assert.deepEqual(groups.hidden, [hidden])
+})
+
+test('keeps confirmed unavailable friends, including haozi.moe, out of the active list', () => {
+  const haozi = hiddenFriends.find(link => link.url === 'https://haozi.moe/')
+  assert.equal(haozi?.name, '月月月子喵')
+
+  const groups = splitFriendsByHiddenLinks(
+    [{ ...friend, name: '月月月子喵', url: 'http://haozi.moe' }],
+    hiddenFriends,
+  )
+
+  assert.deepEqual(groups.active, [])
+  assert.equal(groups.hidden.some(link => link.name === '月月月子喵'), true)
 })

--- a/utils/friends.ts
+++ b/utils/friends.ts
@@ -200,6 +200,41 @@ export function chooseInitialFriends(buildLinks: unknown, cachedLinks: unknown) 
   return normalizeFriends(cachedLinks)
 }
 
+export function applyFriendOverrides(
+  links: FriendLink[],
+  overrides: Record<string, Partial<FriendLink>>,
+) {
+  return links.map(link => ({ ...link, ...overrides[link.url] }))
+}
+
+export function friendUrlKey(value: string) {
+  try {
+    const url = new URL(value)
+    const pathname = url.pathname.replace(/\/+$/, '')
+    return `${url.hostname.toLowerCase()}${pathname}${url.search}`
+  }
+  catch {
+    return value.replace(/\/+$/, '').toLowerCase()
+  }
+}
+
+export function splitFriendsByHiddenLinks(
+  links: FriendLink[],
+  hiddenLinks: FriendLink[],
+) {
+  const currentByUrl = new Map(
+    links.map(link => [friendUrlKey(link.url), link]),
+  )
+  const hiddenUrls = new Set(
+    hiddenLinks.map(link => friendUrlKey(link.url)),
+  )
+
+  return {
+    active: links.filter(link => !hiddenUrls.has(friendUrlKey(link.url))),
+    hidden: hiddenLinks.map(link => currentByUrl.get(friendUrlKey(link.url)) ?? link),
+  }
+}
+
 export function shuffleFriends(
   links: FriendLink[],
   random: () => number = Math.random,


### PR DESCRIPTION
## What changed

- restore the hidden-friends section with an accessible, styled disclosure UI
- separate confirmed unavailable sites from the active randomized list
- add `haozi.moe` and seven other confirmed unavailable friends to the hidden list
- fix randomized list updates by remounting `YunLinks` after shuffled data changes
- add `pnpm check:friends` for repeatable availability checks and JSON reports
- update Bess Croft's current URL

## Root cause

The old hidden section had been empty since the Valaxy migration. In addition, `YunLinks` snapshots its initial array through `useRandomData`, so replacing the parent prop after hydration did not update the rendered order. The initial manual unavailable-site pass only promoted DNS failures, which missed `haozi.moe`: its DNS still resolves, but HTTPS fails during TLS setup and HTTP serves a custom 404 page.

## Validation

- `pnpm test` — 17 passing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- browser QA on `/links/`: collapsed/expanded states, active/hidden separation, `haozi.moe` visibility, count/date, console health
